### PR TITLE
Configure minio to publish to kafka

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -17,7 +17,7 @@ services:
       - "9001:9001"
     depends_on:
       - zookeeper
-      # - kafka
+      - kafka
     networks:
       - microservices
   zookeeper:

--- a/minio.env
+++ b/minio.env
@@ -3,8 +3,9 @@ MINIO_ROOT_USER=minioadmin
 MINIO_ROOT_PASSWORD=minioadmin
 # MINIO_ACCESS_KEY=minio
 # MINIO_SECRET_KEY=minio123
+MINIO_NOTIFY_KAFKA_ENABLE="on"
 MINIO_NOTIFY_KAFKA_BROKERS="kafka:9092"
-MINIO_NOTIFY_KAFKA_TOPIC="minio-topic"
+MINIO_NOTIFY_KAFKA_TOPIC="minio-upload-topic"
 MINIO_NOTIFY_KAFKA_COMMENT="That's just a comment in env variable"
 # Minio custom
 X_MINIO_DOCKER_SERVICE=minio-server


### PR DESCRIPTION
Minio documentation: [Publish Events to Kafka](https://min.io/docs/minio/linux/administration/monitoring/publish-events-to-kafka.html)